### PR TITLE
[Add]deviseのscope設定変更・Therapistモデル生成・add_columnマイグレーション実行_#62

### DIFF
--- a/app/models/therapist.rb
+++ b/app/models/therapist.rb
@@ -1,0 +1,22 @@
+class Therapist < ApplicationRecord
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :validatable,
+         :confirmable, :lockable, :timeoutable, :trackable #追加モジュール
+
+  # has_secure_password
+  # mount_uploader :image, ImageUploader
+  enum sex: {
+    男性:0, 女性:1, その他:2, 無回答:3
+  }
+  enum pref: {
+    北海道:1,青森県:2,岩手県:3,宮城県:4,秋田県:5,山形県:6,福島県:7,
+    茨城県:8,栃木県:9,群馬県:10,埼玉県:11,千葉県:12,東京都:13,神奈川県:14,
+    新潟県:15,富山県:16,石川県:17,福井県:18,山梨県:19,長野県:20,
+    岐阜県:21,静岡県:22,愛知県:23,三重県:24,
+    滋賀県:25,京都府:26,大阪府:27,兵庫県:28,奈良県:29,和歌山県:30,
+    鳥取県:31,島根県:32,岡山県:33,広島県:34,山口県:35,
+    徳島県:36,香川県:37,愛媛県:38,高知県:39,
+    福岡県:40,佐賀県:41,長崎県:42,熊本県:43,大分県:44,宮崎県:45,鹿児島県:46,沖縄県:47
+  }
+  # enum license: {}
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -244,7 +244,7 @@ Devise.setup do |config|
   # Turn scoped views on. Before rendering "sessions/new", it will first check for
   # "users/sessions/new". It's turned off by default because it's slower if you
   # are using only default views.
-  # config.scoped_views = false
+  config.scoped_views = true
 
   # Configure the default scope given to Warden. By default it's the first
   # devise role declared in your routes (usually :user).

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  devise_for :therapists
   devise_for :customers
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#create'

--- a/db/migrate/20200918100717_devise_create_therapists.rb
+++ b/db/migrate/20200918100717_devise_create_therapists.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class DeviseCreateTherapists < ActiveRecord::Migration[5.2]
+  def change
+    create_table :therapists do |t|
+      # Database authenticatable
+      t.string :email,              null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
+
+      # Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      # Rememberable
+      t.datetime :remember_created_at
+
+      # Trackable
+      t.integer  :sign_in_count, default: 0, null: false
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.string   :current_sign_in_ip
+      t.string   :last_sign_in_ip
+
+      # Confirmable
+      t.string   :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+      t.string   :unconfirmed_email # Only if using reconfirmable
+
+      # Lockable
+      t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      t.string   :unlock_token # Only if unlock strategy is :email or :both
+      t.datetime :locked_at
+
+      t.timestamps null: false
+    end
+
+    add_index :therapists, :email,                unique: true
+    add_index :therapists, :reset_password_token, unique: true
+    add_index :therapists, :confirmation_token,   unique: true
+    add_index :therapists, :unlock_token,         unique: true
+  end
+end

--- a/db/migrate/20200918111502_add_columns_to_therapists.rb
+++ b/db/migrate/20200918111502_add_columns_to_therapists.rb
@@ -1,0 +1,16 @@
+class AddColumnsToTherapists < ActiveRecord::Migration[5.2]
+  def change
+    add_column :therapists, :name, :string
+    add_column :therapists, :sex, :integer
+    add_column :therapists, :age, :integer
+    add_column :therapists, :pref, :integer
+    add_column :therapists, :postal_code, :string
+    add_column :therapists, :city, :string
+    add_column :therapists, :address, :string
+    add_column :therapists, :nearest_station, :string
+    add_column :therapists, :image, :string
+    add_column :therapists, :license, :integer
+    add_column :therapists, :self_introduction, :string
+    add_column :therapists, :work_experience, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_18_065824) do
+ActiveRecord::Schema.define(version: 2020_09_18_111502) do
 
   create_table "customers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -45,6 +45,44 @@ ActiveRecord::Schema.define(version: 2020_09_18_065824) do
     t.index ["email"], name: "index_customers_on_email", unique: true
     t.index ["reset_password_token"], name: "index_customers_on_reset_password_token", unique: true
     t.index ["unlock_token"], name: "index_customers_on_unlock_token", unique: true
+  end
+
+  create_table "therapists", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.integer "failed_attempts", default: 0, null: false
+    t.string "unlock_token"
+    t.datetime "locked_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "name"
+    t.integer "sex"
+    t.integer "age"
+    t.integer "pref"
+    t.string "postal_code"
+    t.string "city"
+    t.string "address"
+    t.string "nearest_station"
+    t.string "image"
+    t.integer "license"
+    t.string "self_introduction"
+    t.string "work_experience"
+    t.index ["confirmation_token"], name: "index_therapists_on_confirmation_token", unique: true
+    t.index ["email"], name: "index_therapists_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_therapists_on_reset_password_token", unique: true
+    t.index ["unlock_token"], name: "index_therapists_on_unlock_token", unique: true
   end
 
 end

--- a/test/fixtures/therapists.yml
+++ b/test/fixtures/therapists.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/therapist_test.rb
+++ b/test/models/therapist_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class TherapistTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
close #62 
- devise.rbのscope configを変更
- deviseを用いてTherapistモデル生成
- therapist.rbにenumを定義、deviseの追加モジュールを記述
- therapistsテーブルのadd_columnマイグレーション実行
- ルーティングにtherapistsを追加

- [ ] not null制約はつけてない
- [ ] license(免許)カラムはenumで定義したい